### PR TITLE
Make region-list geoJSON format compatible

### DIFF
--- a/Two10.CountryLookup/ReverseLookup.cs
+++ b/Two10.CountryLookup/ReverseLookup.cs
@@ -78,6 +78,8 @@ namespace Two10.CountryLookup
 
         static IEnumerable<string> LoadFile()
         {
+            // The whole file is not being deserialized to not waste memory unnecessarily.
+            // Deserializing each line separately should consume less resources.
             var assembly = Assembly.GetExecutingAssembly();
             using (var stream = assembly.GetManifestResourceStream(assembly.GetManifestResourceNames().First()))
             using (var reader = new StreamReader(stream))
@@ -85,11 +87,17 @@ namespace Two10.CountryLookup
                 string line = null;
                 while ((line = reader.ReadLine()) != null)
                 {
+                    // Skip root json object (first and last lines)
+                    if (line.Length < 100)
+                        continue;
+
+                    // Remove trailing commas that make file geojson compatible
+                    if (line[line.Length - 1] == ',')
+                        line = line.Remove(line.Length - 1, 1);
+
                     yield return line;
                 }
             }
         }
-
-
     }
 }

--- a/Two10.CountryLookup/Two10.CountryLookup.csproj
+++ b/Two10.CountryLookup/Two10.CountryLookup.csproj
@@ -51,7 +51,7 @@
     <Compile Include="GeoJsonParser.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="region-list.json" />
+    <EmbeddedResource Include="region-list.geojson" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
So that Github can render regions nicely on a world map.
See https://help.github.com/articles/mapping-geojson-files-on-github/

The result can be seen at https://github.com/vansha/Two10.CountryLookup/blob/f16d074d5524aa8e31dd0e3e1648b50fbbaf416e/Two10.CountryLookup/region-list.geojson

To make this work, countries list should be a valid json file. This explains the hack in parsing part.